### PR TITLE
feat: 크루 페이지 조회 응답에 crewId 추가

### DIFF
--- a/src/main/java/clofi/runningplanet/crew/dto/response/FindCrewWithMissionResDto.java
+++ b/src/main/java/clofi/runningplanet/crew/dto/response/FindCrewWithMissionResDto.java
@@ -7,6 +7,7 @@ import clofi.runningplanet.crew.domain.Crew;
 import clofi.runningplanet.crew.dto.RuleDto;
 
 public record FindCrewWithMissionResDto(
+	Long crewId,
 	int crewLevel,
 	String crewName,
 	String introduction,
@@ -22,7 +23,8 @@ public record FindCrewWithMissionResDto(
 ) {
 	public FindCrewWithMissionResDto(Crew crew, List<String> tags, String imgPath, List<Double> missionProgress,
 		int memberCnt, boolean isCrewLeader) {
-		this(crew.getCrewLevel(), crew.getCrewName(), crew.getIntroduction(), memberCnt, crew.getLimitMemberCnt(), tags,
+		this(crew.getId(), crew.getCrewLevel(), crew.getCrewName(), crew.getIntroduction(), memberCnt,
+			crew.getLimitMemberCnt(), tags,
 			crew.getCategory(), new RuleDto(crew.getRuleRunCnt(), crew.getRuleDistance()), crew.getTotalDistance(),
 			missionProgress, isCrewLeader, imgPath);
 	}

--- a/src/test/java/clofi/runningplanet/crew/controller/CrewControllerTest.java
+++ b/src/test/java/clofi/runningplanet/crew/controller/CrewControllerTest.java
@@ -359,7 +359,7 @@ class CrewControllerTest {
 		//given
 		Long crewId = 1L;
 
-		FindCrewWithMissionResDto expected = new FindCrewWithMissionResDto(1, "크루명", "크루 소개", 10, 10, List.of("태그"),
+		FindCrewWithMissionResDto expected = new FindCrewWithMissionResDto(1L, 1, "크루명", "크루 소개", 10, 10, List.of("태그"),
 			RUNNING, new RuleDto(5, 999), 2, List.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0), true, "https://test.com");
 
 		given(crewService.findCrewWithMission(anyLong(), anyLong()))


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 이슈 번호
- issue: #162
- close: #162

### 반영 브랜치
feat/#162-> dev

### 변경 사항
- [x] 크루 페이지 조회 시 crewId 응답 추가

### 테스트 결과
![image](https://github.com/Clo-fi/Running-planet-server/assets/94841127/e86f40be-e70b-4a22-8dec-f62ade12fd35)

