### PR TITLE
fix: 소켓 헤더 접근 방법 수정

### DIFF
--- a/src/main/java/clofi/runningplanet/socket/StompHandler.java
+++ b/src/main/java/clofi/runningplanet/socket/StompHandler.java
@@ -5,7 +5,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -28,10 +27,7 @@ public class StompHandler implements ChannelInterceptor {
 
 	@Override
 	public Message<?> preSend(Message<?> message, MessageChannel channel) {
-		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-		if (accessor == null) {
-			throw new IllegalArgumentException("HeaderAccessor is null");
-		}
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
 		if (StompCommand.CONNECT.equals(accessor.getCommand())) {
 			String token = extractToken(accessor.getFirstNativeHeader(AUTHORIZATION_HEADER));


### PR DESCRIPTION
MessageHeaderAccessor.getAccessor -> StompHeaderAccessor.wrap

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 이슈 번호
- issue: #174 
- close: #174 

### 반영 브랜치
feat/#174-> dev

### 변경 사항
- [x] MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class); -> StompHeaderAccessor.wrap(message);

### 테스트 결과
![image](https://github.com/Clo-fi/Running-planet-server/assets/94841127/aa16fa1b-ea11-4515-9822-0a1b7e5ac0f9)
