### PR TITLE
Feat : 크루 신청 목록 조회에서 승인/거부 인원도 조회되는 문제 수정

### DIFF
--- a/src/main/java/clofi/runningplanet/crew/repository/CrewApplicationRepository.java
+++ b/src/main/java/clofi/runningplanet/crew/repository/CrewApplicationRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import clofi.runningplanet.crew.domain.Approval;
 import clofi.runningplanet.crew.domain.CrewApplication;
 
 @Repository
@@ -13,4 +14,6 @@ public interface CrewApplicationRepository extends JpaRepository<CrewApplication
 	Optional<CrewApplication> findByCrewIdAndMemberId(Long crewId, Long id);
 
 	List<CrewApplication> findAllByCrewId(Long crewId);
+
+	List<CrewApplication> findAllByCrewIdAndApproval(Long crewId, Approval approval);
 }

--- a/src/main/java/clofi/runningplanet/crew/service/CrewService.java
+++ b/src/main/java/clofi/runningplanet/crew/service/CrewService.java
@@ -17,6 +17,7 @@ import clofi.runningplanet.common.exception.ConflictException;
 import clofi.runningplanet.common.exception.NotFoundException;
 import clofi.runningplanet.common.exception.UnauthorizedException;
 import clofi.runningplanet.common.service.S3StorageManagerUseCase;
+import clofi.runningplanet.crew.domain.Approval;
 import clofi.runningplanet.crew.domain.ApprovalType;
 import clofi.runningplanet.crew.domain.Crew;
 import clofi.runningplanet.crew.domain.CrewApplication;
@@ -119,7 +120,8 @@ public class CrewService {
 		validateLeaderPrivilege(crewId, memberId);
 		checkCrewExistById(crewId);
 
-		List<CrewApplication> crewApplicationList = crewApplicationRepository.findAllByCrewId(crewId);
+		List<CrewApplication> crewApplicationList = crewApplicationRepository.findAllByCrewIdAndApproval(crewId,
+			Approval.PENDING);
 		List<GetApplyCrewResDto> getApplyCrewResDtos = makeGetApplyDtoList(crewApplicationList);
 		return new ApprovalMemberResDto(getApplyCrewResDtos);
 	}

--- a/src/test/java/clofi/runningplanet/crew/service/CrewServiceTest.java
+++ b/src/test/java/clofi/runningplanet/crew/service/CrewServiceTest.java
@@ -471,7 +471,7 @@ class CrewServiceTest {
 			.willReturn(Optional.of(crewMember));
 		given(crewRepository.existsById(anyLong()))
 			.willReturn(true);
-		given(crewApplicationRepository.findAllByCrewId(anyLong()))
+		given(crewApplicationRepository.findAllByCrewIdAndApproval(anyLong(), any()))
 			.willReturn(List.of(crewApplication1, crewApplication2));
 
 		//when
@@ -503,7 +503,7 @@ class CrewServiceTest {
 			.willReturn(Optional.of(crewMember));
 		given(crewRepository.existsById(anyLong()))
 			.willReturn(true);
-		given(crewApplicationRepository.findAllByCrewId(anyLong()))
+		given(crewApplicationRepository.findAllByCrewIdAndApproval(anyLong(), any()))
 			.willReturn(Collections.emptyList());
 
 		//when


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 이슈 번호
- issue: #201 
- close: #201

### 반영 브랜치
feat/#201 -> dev

### 변경 사항
- pending 인원만 조회하도록 로직 수정

### 테스트 결과
![image](https://github.com/user-attachments/assets/bc73c842-9985-49a0-856b-de3bac701138)
